### PR TITLE
DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ _ has_many :groups, through:  :groups_users
 |Column|Type|Options|
 |------|----|-------|
 |groupname|string|null: false|
-|chatmembername|string|null: false|
 ### Association
 _ has_many :posts
 _ has_many :users, through:  :groups_users
@@ -30,8 +29,8 @@ _ has_many :users, through:  :groups_users
 ## postsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|integer|null: false|
-|image|integer|null: false|
+|text|text|null: false|
+|image|text|null: false|
 ### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
+## ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|username|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|password|string|null: false, unique: true|
+### Association
+_ has_many :posts
+_ has_many :groups, through:  :groups_users
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+|chatmembername|string|null: false|
+### Association
+_ has_many :posts
+_ has_many :users, through:  :groups_users
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## postsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|integer|null: false|
+|image|integer|null: false|
+### Association
+- belongs_to :group
+- belongs_to :user
+
 # README
 
 This README would normally document whatever steps are necessary to get the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|null: false, unique: true|
+|username|string|index: true, null: false, unique: true|
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ _ has_many :users, through:  :groups_users
 ## postsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
-|image|text|null: false|
+|text|text||
+|image|text||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|index: true, null: false, unique: true|
+|name|string|index: true, null: false, unique: true|
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 ### Association
 _ has_many :posts
+_ has_many :groups_users
 _ has_many :groups, through:  :groups_users
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 ### Association
 _ has_many :posts
+_ has_many :groups_users
 _ has_many :users, through:  :groups_users
 
 ## groups_usersテーブル
@@ -31,6 +33,8 @@ _ has_many :users, through:  :groups_users
 |------|----|-------|
 |text|text|null: false|
 |image|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user


### PR DESCRIPTION
# What
ChatSpaceのデータベースを設計する。
usersテーブル、groupsテーブル、postsテーブル(messageのテーブル)、groups_usersテーブルを実装。
usersテーブルとgroupsテーブルの中間テーブルとしてgroups_usersテーブルを実装。
usersテーブルのusernameにのみindexを貼った。
usersテーブルのusername、email、passwordに一意性制約を設けた。

# Why
usersテーブルとgroupsテーブルが多対多のアソシエーションとなっているため。
グループにチャットメンバーを追加するときに検索表示できるようにするため。
なりすましや不正侵入を防ぐため。

